### PR TITLE
Implementing needed services

### DIFF
--- a/src/processmanagement/processmanagement.controller.ts
+++ b/src/processmanagement/processmanagement.controller.ts
@@ -1,11 +1,16 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Get, Post, Body } from '@nestjs/common';
 import { InputFileEto } from './etos/input-file.eto';
 import { MergerEto } from './etos/merger.eto';
 import { InputReader } from './inputreader/input-reader';
 
 @Controller('processmanagement')
 export class ProcessmanagementController {
-  @Post('/isValidInput')
+  @Get('tsplugin/isConnectionReady')
+  isConnectionReady() {
+    return true;
+  }
+
+  @Post('tsplugin/isValidInput')
   isValidInput(@Body() inputFile: InputFileEto) {
     const filename: string = inputFile.filename.toLowerCase();
 

--- a/test/beautifyrequest.e2e-spec.ts
+++ b/test/beautifyrequest.e2e-spec.ts
@@ -19,7 +19,7 @@ describe('Testing basic requests to the server', () => {
     const content = `class a {
                     b(c:any):void;
                   }`;
-    const file: InputFileEto = new InputFileEto("", content, "");
+    const file: InputFileEto = new InputFileEto('', content, '');
 
     return request(app.getHttpServer())
       .post('/processmanagement/tsplugin/beautify')


### PR DESCRIPTION
We had to implement a new service called `isConnectionReady` because we found an issue when a server was already deployed in our port. The server answered `400 bad request` and CobiGen thought it was the correct server.

With this new approach, we know we are using the correct server.